### PR TITLE
paths need to be platform-specific

### DIFF
--- a/github-extra/PKGBUILD
+++ b/github-extra/PKGBUILD
@@ -5,15 +5,15 @@ pkgver=1.0.0
 pkgrel=1
 pkgdesc="Environment customizations for Git Shell"
 arch=('i686' 'x86_64')
-url="https://github.com/github/msysgit"
+url="https://github.com/github/ghfw-build-extra"
 license=('Apache 2.0')
 depends=('git-extra')
 
 package() {
-  install -d -m755 $pkgdir/etc
-  install -m755 $srcdir/gitattributes $pkgdir/etc/gitattributes
-  install -m755 $srcdir/gitattributes.suggested $pkgdir/etc/gitattributes.suggested
-  install -m755 $srcdir/gitconfig $pkgdir/etc/gitconfig
-  install -m755 $srcdir/gitignore.suggested $pkgdir/etc/gitignore.suggested
+  install -d -m755 $pkgdir/${MINGW_PREFIX}/etc
+  install -m755 $srcdir/gitattributes $pkgdir/${MINGW_PREFIX}/etc/gitattributes
+  install -m755 $srcdir/gitattributes.suggested $pkgdir/${MINGW_PREFIX}/etc/gitattributes.suggested
+  install -m755 $srcdir/gitconfig $pkgdir/${MINGW_PREFIX}/etc/gitconfig
+  install -m755 $srcdir/gitignore.suggested $pkgdir/${MINGW_PREFIX}/etc/gitignore.suggested
 }
 


### PR DESCRIPTION
There is an implicit `$prefix/` defined as the root of the Git installation.
- For Git 1.x, this has not been used (i.e. `/`)
- For Git 2.x, this is now based on the architecture you are packaging for - e.g. `/mingw32/` or `/mingw64/`

cc @dscho
