### PR TITLE
one last config tweak

### DIFF
--- a/github-extra/PKGBUILD
+++ b/github-extra/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Brendan Forster <brendan@github.com>
 
 pkgname=('github-extra')
-pkgver=1.0.5
+pkgver=1.0.6
 pkgrel=1
 pkgdesc="Environment customizations for Git Shell"
 arch=('any')

--- a/github-extra/resources/gitconfig
+++ b/github-extra/resources/gitconfig
@@ -32,7 +32,7 @@
 	format = html
 
 [http]
-	sslcainfo = /usr/ssl/certs/ca-bundle-ghfw.crt
+	sslcainfo = /usr/ssl/certs/ca-bundle.crt
 
 [diff "astextplain"]
 	textconv = astextplain


### PR DESCRIPTION
GitHub Desktop will generate a new config containing the system certificates and the ones bundled with curl. For now, we should just use the default certificates...
