### PR TITLE
[WIP] move GitPad package into Git Shell installation

### DIFF
--- a/gitpad/.gitignore
+++ b/gitpad/.gitignore
@@ -1,0 +1,4 @@
+pkg
+src
+*.zip
+*.xz

--- a/gitpad/PKGBUILD
+++ b/gitpad/PKGBUILD
@@ -1,0 +1,17 @@
+# Maintainer: Brendan Forster <brendan@github.com>
+
+pkgname=('gitpad')
+pkgver=1.4.0
+pkgrel=1
+pkgdesc="A shim for using your default editor for text files with Git"
+arch=('any')
+url="https://github.com/github/gitpad"
+license=('Apache 2.0')
+
+source=("https://github.com/github/gitpad/releases/download/v$pkgver/Gitpad.zip")
+md5sums=('dceca59747faadbad9d22b871b8567fc')
+
+package() {
+  install -d -m755 $pkgdir/usr/bin
+  install -m644 GitPad.exe $pkgdir/usr/bin/
+}


### PR DESCRIPTION
As part of the long-awaited upgrade to Git Shell, there's some extra customizations we can do to simplify things. For example, [Gitpad](https://github.com/github/gitpad) is something we package up and unzip independently, so whatever text editor you have configured will just work with Git Shell.

This PR moves that package (which is just an exe) into the Git Shell installation under `/usr/bin`. One less thing for us to worry about, and given how little it's changed I think we can couple these together without any real drama. 
- [x] create package locally
- [x] test installation into SDK
- [ ] on vanilla install, first launch requires .NET 3.5 :cry:
