### PR TITLE
copy assemblies post-install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 /git-extra/pkg/
 /git-extra/src/
 /git-extra/git-extra-*.pkg.tar.xz
+/git-shell/root/VERSION
+/git-shell/root/post-install.bat
+/git-shell/root/etc/
+
 /installer/ReleaseNotes.html
 /installer/bindimage.txt
 /installer/install.iss

--- a/git-shell/release.sh
+++ b/git-shell/release.sh
@@ -71,5 +71,3 @@ die "Could not install 7-Zip"
 
 cd / && 7za a $OPTS7 $TARGET $LIST
 echo "Success! You will find the new installer at \"$TARGET\"."
-
-rm -rf $SCRIPT_PATH/root 

--- a/git-shell/root/etc/post-install/13-copy-dlls.post
+++ b/git-shell/root/etc/post-install/13-copy-dlls.post
@@ -1,0 +1,22 @@
+ln_or_cp () {
+	ln "$@" ||
+	cp "$@" ||
+	echo "ERROR: could not link $*" >&2
+}
+
+hardlink_all_dlls () {
+	exec_path="$(git --exec-path)" ||
+	return
+
+	prefix_path="${exec_path%libexec/git-core}"
+	if test "a$prefix_path" != "a$exec_path"
+	then
+		for dll in "$prefix_path"bin/*.dll
+		do
+			test -f "$exec_path"/${dll##*/} ||
+			ln_or_cp "$dll" "$exec_path"
+		done
+	fi
+}
+
+hardlink_all_dlls


### PR DESCRIPTION
Something I overlooked while packaging turned out to be super-useful for people who have things in their  `System32` or `SysWOW64` which clash with what Git for Windows needs.

A bit of additional tweaks to the script as a result.
